### PR TITLE
#1 Check that t._connection is not null

### DIFF
--- a/lib/rabbit-chatter.js
+++ b/lib/rabbit-chatter.js
@@ -65,7 +65,7 @@ class RabbitChatter{
 			})
 			.then(() => { 
 				clearTimeout(t._connectionTimer);
-				t._connectionTimer = setTimeout(() => { t._connection.close(); t._connection = null; }, 500); 
+				t._connectionTimer = setTimeout(() => { t._connection && t._connection.close(); t._connection = null; }, 500); 
 				callback(); 
 			})
 			.catch(t.handleError);


### PR DESCRIPTION
Sometime I got t._connection is null in the timer, this quick fix should prevent this.
