### PR TITLE
Improve error logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ A function for handling errors if it fails when sending the log to the queue.
 The default function looks like this:
 ```javascript
 	function(ex) {
-		console.log('ERROR in rabbit-chatter: ' + util.inspect(ex, { depth: null }));
+		console.error('ERROR in rabbit-chatter:', ex.stack);
 	}
 ```
 

--- a/lib/rabbit-chatter.js
+++ b/lib/rabbit-chatter.js
@@ -6,7 +6,7 @@ const dontCollide = require('dont-collide');
 
 class ErrorHelper{
 	static defaultError(ex){
-		console.log('ERROR in rabbit-chatter: ' + JSON.stringify(ex, null, 4));
+		console.error('ERROR in rabbit-chatter:', ex.stack);
 	}
 }
 


### PR DESCRIPTION
Currently whenever there is an error thrown the `defaultError` function logs the error as:
`ERROR in rabbit-chatter: {}`.

Usually, an `error` is of type `Error` which has a `message` and `stack` property. And the `stack` property also starts with the error `message`.

So, this PR proposes to simplify and correct the default error logging function.