### PR TITLE
Fix logic of message sender.

### DIFF
--- a/lib/rabbit-chatter.js
+++ b/lib/rabbit-chatter.js
@@ -4,93 +4,137 @@ const amqplib = require('amqplib');
 const uuid = require('uuid');
 const dontCollide = require('dont-collide');
 
-class ErrorHelper{
-	static defaultError(ex){
-		console.error('ERROR in rabbit-chatter:', ex.stack);
-	}
+class ErrorHelper {
+    static defaultError(ex) {
+        console.error('ERROR in rabbit-chatter:', ex.stack);
+    }
 }
 
-class RabbitChatter{
-	constructor(options){
+class RabbitChatter {
+    constructor(options) {
 
-		if(!options)
-			options = {};
+        if (!options)
+            options = {};
 
-		this.appId = options.appId;
-		this.handleError = options.handleError || ErrorHelper.defaultError;
-		this.silent = options.silent || false;
-		this.timeout = options.timeout || 1000;
+        this.appId = options.appId;
+        this.handleError = options.handleError || ErrorHelper.defaultError;
+        this.silent = options.silent || false;
+        this.timeout = options.timeout || 1000;
 
-		const protocol = options.protocol || 'amqp';
-		const username = options.username || 'guest';
-		const password = options.password || 'guest';
-		const host = options.host || 'localhost';
-		const virtualHost = options.virtualHost ? '/' + options.virtualHost : '';
-		const port = options.port || 5672;
+        const protocol = options.protocol || 'amqp';
+        const username = options.username || 'guest';
+        const password = options.password || 'guest';
+        const host = options.host || 'localhost';
+        const virtualHost = options.virtualHost ? '/' + options.virtualHost : '';
+        const port = options.port || 5672;
 
-		this.amqp = {};
-		this.amqp.host = `${protocol}://${username}:${password}@${host}:${port}${virtualHost}`;
-		
-		this.amqp.exchangeType = options.exchangeType || 'topic';
-		this.amqp.exchangeName = options.exchangeName || '';
-		this.amqp.routingKey = options.routingKey || '';
-		this.amqp.durable = options.durable || false;
+        this.amqp = {};
+        this.amqp.host = `${protocol}://${username}:${password}@${host}:${port}${virtualHost}`;
 
-		this._connection = null;
-		this._connectionTimer = null;
-		this._dc = dontCollide();
-	}
+        this.amqp.exchangeType = options.exchangeType || 'topic';
+        this.amqp.exchangeName = options.exchangeName || '';
+        this.amqp.routingKey = options.routingKey || '';
+        this.amqp.durable = options.durable || false;
 
-	static rabbit(options){
-		return new RabbitChatter(options);
-	}
+        this._connectionPool = [];
+        this._dc = dontCollide();
 
-	chat(msg, properties, callback){
-		const t = this;
+        this._sendMessageToQueue = (msg, properties, callback) => {
+            this._getConnectionChannel()
+                .then((channel) => {
+                    return channel.assertExchange(this.amqp.exchangeName, this.amqp.exchangeType, { durable: this.amqp.durable })
+                        .then((ok) => {
+                            return new Promise((resolve, reject) => {
+                                if (!ok) return reject();
+                                this._resetTimeout(channel.connection);
+                                const publish = channel && channel.publish(this.amqp.exchangeName, this.amqp.routingKey, new Buffer(msg), properties);
+                                if (!this.silent && publish) console.log("Message send from rabbit-chat: %s", msg);
+                                callback(channel);
+                                return resolve(publish);
+                            })
+                        });
+                })
+                .catch(this.handleError);
+        };
 
-		properties = properties || {};
-		properties.appId = properties.appId || t.appId;
-		properties.correlationId = properties.correlationId || uuid.v4();
-		properties.timestamp = properties.timestamp || Date.now();
+        this._getConnectionChannel = () => {
+            if (this._connectionPool.length) {
+                return new Promise((resolve, _) => {
+                    const activeConnection = this._connectionPool.filter((conn) => !conn.closing)[0];
 
-		callback = callback || (() => {});
+                    if (!activeConnection) return resolve(this._createNewConnectionChannel());
 
-		t._dc.throttle(t.sendMessageToQueue, t, msg, properties, callback);
-	}
+                    this._resetTimeout(activeConnection);
 
-	sendMessageToQueue(t, msg, properties, callback){
-		t.getConnection()
-			.then((channel) => {
-				return channel.assertExchange(t.amqp.exchangeName, t.amqp.exchangeType, {durable: t.amqp.durable})
-					.then((ok) => {
-						let publish = channel.publish(t.amqp.exchangeName, t.amqp.routingKey, new Buffer(msg), properties);
+                    const activeChannel = this._getActiveChannel(activeConnection);
 
-						if(!t.silent) console.log("Message send from rabbit-chat: %s", msg);
-			    		
-						callback(channel); 
+                    if (!activeChannel) this._close(activeConnection);
 
-			    		return publish;
-				  	});
-			})
-			.then(() => { 
-				clearTimeout(t._connectionTimer);
-				t._connectionTimer = setTimeout(() => { t._connection && t._connection.close(); t._connection = null; }, t.timeout); 
-			})
-			.catch(t.handleError);
-	}
+                    resolve(activeChannel || this._createNewConnectionChannel());
+                });
+            } else {
+                return this._createNewConnectionChannel();
+            }
+        };
 
-	getConnection(){
-		const t = this;
+        this._createNewConnectionChannel = () => {
+            return amqplib
+                .connect(this.amqp.host)
+                .then((conn) => {
+                    conn.connection.timeout = this._setTimeout(conn.connection);
+                    this._connectionPool.push(conn.connection);
+                    return conn.createChannel();
+                })
+        };
 
-		if(t._connection){
-			return new Promise((resolve, reject) => { resolve(t._connection.createChannel()); });
-		}
-		else{
-			return amqplib
-				.connect(t.amqp.host)
-				.then((conn) => { t._connection = conn; return t._connection.createChannel(); });
-		}
-	}
+        this._setTimeout = (connection) => {
+            return setTimeout(() => {
+                this._close(connection);
+            }, this.timeout);
+        };
+
+        this._close = (connection) => {
+            connection.closing = true;
+            this._connectionPool.splice(this._connectionPool.indexOf(connection), 1);
+
+            const activeChannel = this._getActiveChannel(connection);
+            if (activeChannel) {
+                activeChannel.close()
+                    .then(() => connection.close());
+            } else {
+                connection.close();
+            }
+        };
+
+        this._getActiveChannel = (connection) => {
+            // channels[1] is the actual channel
+            return connection &&
+                connection.channels &&
+                connection.channels.length > 1 &&
+                connection.channels[1].channel;
+        };
+
+        this._resetTimeout = (connection) => {
+            clearTimeout(connection.timeout);
+            connection.closing = false;
+            connection.timeout = this._setTimeout(connection);
+        }
+    }
+
+    static rabbit(options) {
+        return new RabbitChatter(options);
+    }
+
+    chat(msg, properties, callback) {
+        properties = properties || {};
+        properties.appId = properties.appId || this.appId;
+        properties.correlationId = properties.correlationId || uuid.v4();
+        properties.timestamp = properties.timestamp || Date.now();
+
+        callback = callback || (() => { });
+
+        this._dc.throttle(this._sendMessageToQueue, msg, properties, callback);
+    }
 }
 
-module.exports= RabbitChatter;
+module.exports = RabbitChatter;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A message emitter for RabbitMQ",
   "main": "lib/rabbit-chatter.js",
   "scripts": {
-    "test": "mocha test/."
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -26,7 +26,8 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "sinon": "^1.17.4"
+    "chai": "^4.0.0",
+    "mocha": "^3.4.2",
+    "sinon": "^2.3.2"
   }
 }


### PR DESCRIPTION
This PR fixes #8 by doing the following:

1. Improves the flow logic by
**a.** using the concept of connection pool
**b.** using a connection `closing` marker
**c.** registering the connection timeout on connection creation
**d.** moving private function inside the constructor making them truly private (and preserving `this` in their scope)

2. Improves the connection handling by
**a.** each connection carrying its own `timeout`
**b.** each connection being stored in the connection pool upon creation
**c.** removing a connection from the pool upon connection closing
**d**. retrieving an open connection (that is not marked as `closing`) from the pool and keeps it alive, resetting its `timeout`
**e.** Handling time racing cases where a new connection is created and stored in the pool, in case the connection pool still had a connection, passing the condition check but that connection got closed in the meanwhile

3. Refactoring test cases to reflect the code refactoring

@TBear79
In the process of refactoring the code, I applied also code formatting.
The main public API hasn't changed so there shouldn't be any breaking changes to the API (`Winston-Fast-RabbitMQ` still works without making any adjustments) justifying a minor version release (1.3.0). But because we can never be sure how the users use the library I suggest you do a major version release (2.0.0).

**Note:** I'm currently testing this changes in our staging server.