### PR TITLE
fix: encode password to avoid special url characters issues

### DIFF
--- a/lib/rabbit-chatter.js
+++ b/lib/rabbit-chatter.js
@@ -23,7 +23,7 @@ class RabbitChatter {
 
         const protocol = options.protocol || 'amqp';
         const username = options.username || 'guest';
-        const password = options.password || 'guest';
+        const password = encodeURIComponent(options.password) || 'guest';
         const host = options.host || 'localhost';
         const virtualHost = options.virtualHost ? '/' + options.virtualHost : '';
         const port = options.port || 5672;


### PR DESCRIPTION
I was facing this problem. Some complicated passwords may contains multiple specials characters. If they are don't encoded correctly, these characters may cause an issue further in amqplib when the lib try to parse the url (at line : https://github.com/squaremo/amqp.node/blob/962fb9ea3c4ac16368f8006c523b8a39182e11e0/lib/connect.js#L130).